### PR TITLE
Bug fix for ForwardDiffing F with m=1

### DIFF
--- a/ext/JacobiEllipticForwardDiffExt.jl
+++ b/ext/JacobiEllipticForwardDiffExt.jl
@@ -82,10 +82,15 @@ for alg in [JacobiElliptic.CarlsonAlg, JacobiElliptic.FukushimaAlg]
     @eval function ($alg).F(x::U, y::ForwardDiff.Dual{T}) where {T,U}
         yval = y.value
         fval = ($alg).F(x, yval)
-        ∂yf =
-            iszero(yval) ? (2x - sin(2x)) / 8 :
-            ($alg).E(x, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) -
-            sin(2 * x) / (4 * (1 - yval) * sqrt(1 - yval * sin(x)^2))
+        if iszero(yval)
+            ∂yf = (2x - sin(2x)) / 8
+        elseif isone(yval)
+            sec_x = sec(x)
+            tan_x = tan(x)
+            ∂yf = 0.25 * (sec_x * tan_x - log(abs(sec_x + tan_x)))
+        else
+            ∂yf = ($alg).E(x, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) - sin(2 * x) / (4 * (1 - yval) * sqrt(1 - yval * sin(x)^2))
+        end
         ForwardDiff.Dual{T}(fval, ∂yf * y.partials)
     end
 
@@ -97,10 +102,15 @@ for alg in [JacobiElliptic.CarlsonAlg, JacobiElliptic.FukushimaAlg]
         sin_2x = sin(2 * xval)
         sqrt_term = sqrt(1 - yval * sin_x^2)
         ∂xf = inv(sqrt_term)
-        ∂yf =
-            iszero(yval) ? (2xval - sin_2x) / 8 :
-            ($alg).E(xval, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) -
-            sin_2x / (4 * (1 - yval) * sqrt_term)
+        if iszero(yval)
+            ∂yf = (2x - sin(2x)) / 8
+        elseif isone(yval)
+            sec_x = sec(x)
+            tan_x = tan(x)
+            ∂yf = 0.25 * (sec_x * tan_x - log(abs(sec_x + tan_x)))
+        else
+            ∂yf = ($alg).E(x, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) - sin(2 * x) / (4 * (1 - yval) * sqrt(1 - yval * sin(x)^2))
+        end
         ForwardDiff.Dual{T}(fval, ∂xf * x.partials + ∂yf * y.partials)
     end
 

--- a/ext/JacobiEllipticForwardDiffExt.jl
+++ b/ext/JacobiEllipticForwardDiffExt.jl
@@ -103,13 +103,13 @@ for alg in [JacobiElliptic.CarlsonAlg, JacobiElliptic.FukushimaAlg]
         sqrt_term = sqrt(1 - yval * sin_x^2)
         ∂xf = inv(sqrt_term)
         if iszero(yval)
-            ∂yf = (2x - sin(2x)) / 8
+            ∂yf = (2xval - sin_2x) / 8
         elseif isone(yval)
-            sec_x = sec(x)
-            tan_x = tan(x)
+            sec_x = sec(xval)
+            tan_x = tan(xval)
             ∂yf = 0.25 * (sec_x * tan_x - log(abs(sec_x + tan_x)))
         else
-            ∂yf = ($alg).E(x, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) - sin(2 * x) / (4 * (1 - yval) * sqrt(1 - yval * sin(x)^2))
+            ∂yf = ($alg).E(xval, yval) / (2 * yval * (1 - yval)) - fval / (2 * yval) - sin_2x / (4 * (1 - yval) * sqrt_term)
         end
         ForwardDiff.Dual{T}(fval, ∂xf * x.partials + ∂yf * y.partials)
     end

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -183,10 +183,10 @@ end
                 end
 
                 # Special case m = 1:
-                ϕ = 0.5; m = 1.0
-                @test ForwardDiff.derivative(x -> _F(ϕ + x, m), 0.0) ≈ 1.139493927324549 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
-                @test ForwardDiff.derivative(x -> _F(ϕ, m + x), 0.0) ≈ 0.025067566595210033 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
-                @test ForwardDiff.derivative(x -> _F(ϕ + x, m + x), 0.0) ≈ 1.164561493919759 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
+                ϕ_here = 0.5; m_here = 1.0
+                @test ForwardDiff.derivative(x -> _F(ϕ_here + x, m_here), 0.0) ≈ 1.139493927324549 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
+                @test ForwardDiff.derivative(x -> _F(ϕ_here, m_here + x), 0.0) ≈ 0.025067566595210033 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
+                @test ForwardDiff.derivative(x -> _F(ϕ_here + x, m_here + x), 0.0) ≈ 1.164561493919759 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
             end
 
             @testset "Incomplete E" begin

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -185,6 +185,12 @@ end
                 for Tret in (Const, Active), Tϕ in (Const, Active), Tm in (Const, Active)
                     test_reverse(alg.F, Tret, (ϕ, Tϕ), (m, Tm); atol = enzyme_atol)
                 end
+
+                # Special case m = 1:
+                ϕ = 0.5; m = 1.0
+                @test ForwardDiff.derivative(x -> _F(ϕ + x, m), 0.0) ≈ 1.139493927324549 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
+                @test ForwardDiff.derivative(x -> _F(ϕ, m + x), 0.0) ≈ 0.025067566595210033 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
+                @test ForwardDiff.derivative(x -> _F(ϕ + x, m + x), 0.0) ≈ 1.164561493919759 atol = 1e-9 # Number retrieved from ForwardDiff and checked against finite diff
             end
 
             @testset "Incomplete E" begin


### PR DESCRIPTION
This is a small feature enhancement for the partial derivatives via ForwardDiff for calculating `ForwardDiff.derivative(x -> F(0.5, x), 1.0)`, which previously failed due to division by zero. I have added a formula, which is only valid for `k = 1.0`, which covers this error.

The reason behind it: the analytic formula for $\partial F / \partial m$ contains a pole at $m = 1$, even though the result is existent and steady. The implemented formula is a derived version for m being exactly 1.

I did short tests on a few variables, but no thorough testing.

There are still big numeric errors for m around 1: due to heavy cancellation errors, an approximation formula valid not only for m equals 1 would be needed.